### PR TITLE
Update Denmark subdivisions as per ISO 3166-2

### DIFF
--- a/lib/data/subdivisions/DK.yaml
+++ b/lib/data/subdivisions/DK.yaml
@@ -1,89 +1,26 @@
 ---
-? "015"
-:
-  name: København
-  names: København
-? "020"
-:
-  name: Frederiksborg
-  names: Frederiksborg
-? "025"
-:
-  name: Roskilde
-  names: Roskilde
-? "030"
-:
-  name: Vestsjælland
-  names: Vestsjælland
-? "035"
-:
-  name: Storstrøm
-  names: Storstrøm
-? "040"
-:
-  name: Bornholm
-  names: Bornholm
-? "042"
-:
-  name: Fyn
-  names: Fyn
-? "050"
-:
-  name: Sønderjylland
-  names: Sønderjylland
-? "055"
-:
-  name: Ribe
-  names: Ribe
-? "060"
-:
-  name: Vejle
-  names: Vejle
-? "065"
-:
-  name: Ringkøbing
-  names: Ringkøbing
-? "070"
-:
-  name: Århus
-  names: Århus
-? "076"
-:
-  name: Viborg
-  names: Viborg
-080:
-  name: Nordjylland
-  names: Nordjylland
-? "101"
-:
-  name: "København City"
-  names: "København City"
-? "147"
-:
-  name: "Frederiksberg City"
-  names: "Frederiksberg City"
 ? "81"
 :
-  name: "North Jutland"
+  name: "North Denmark Region"
   names:
     - Nordjylland
 ? "82"
 :
-  name: "Central Jutland"
+  name: "Central Denmark Region"
   names:
     - Midtjylland
 ? "83"
 :
-  name: "South Denmark"
+  name: "Region of Southern Denmark"
   names:
     - Syddanmark
 ? "84"
 :
-  name: Capital
+  name: "Capital Region of Denmark"
   names:
-    - "Region Hovedstaden"
+    - Hovedstaden
 ? "85"
 :
-  name: Zeeland
+  name: "Region Zealand"
   names:
-    - SjÃ¦lland
+    - Sjælland


### PR DESCRIPTION
Updates Denmark subdivisions as per ISO 3166-2 (https://en.wikipedia.org/wiki/ISO_3166-2:DK#Current_codes).