### PR TITLE
Add IC for Canary Islands

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -4159,6 +4159,44 @@ HU:
   nationality: Hungarian
   eu_member: true
   postal_code: true
+IC:
+  continent: Europe
+  address_format: ! '{{recipient}}
+
+    {{street}}
+
+    {{postalcode}} {{city}} {{region}}
+
+    {{country}}'
+  alpha2: IC
+  alpha3: IC
+  country_code: '34'
+  currency: EUR
+  international_prefix: '00'
+  ioc: ESP
+  latitude: 28 10 N
+  longitude: 15 40 W
+  name: Canary Islands
+  names:
+  - Canary Islands
+  - Islas Canarias
+  translations:
+    en: Canary Islands
+    es: Islas Canarias
+  national_destination_code_lengths:
+  - 2
+  national_number_lengths:
+  - 9
+  national_prefix: None
+  number: '724'
+  region: Europe
+  subregion: Southern Europe
+  un_locode: IC
+  languages:
+  - es
+  nationality: Spanish
+  eu_member: false
+  postal_code: true
 ID:
   continent: Asia
   address_format: ! '{{recipient}}


### PR DESCRIPTION
According to https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2 the code 'IC' is exceptionally reserved for the Canary Islands, even though the actual country is Spain.

IC - Reserved on request of WCO for area not covered by European Union Customs arrangements. Code taken from name in Spanish: Islas Canarias

Copied data from ES - Spain and modified

Longitude and Latitude taken from https://en.wikipedia.org/wiki/Canary_Islands