### PR TITLE
[bugfix] Fix corrupted names

### DIFF
--- a/lib/data/subdivisions/PL.yaml
+++ b/lib/data/subdivisions/PL.yaml
@@ -1,8 +1,7 @@
 ---
 DS:
-  name: Dolnoslaskie
-  names:
-    - Dolnoslaskie
+  name: Dolnośląskie
+  names: Dolnośląskie
 KP:
   name: Kujawsko-pomorskie
   names: Kujawsko-pomorskie
@@ -10,16 +9,14 @@ LB:
   name: Lubuskie
   names: Lubuskie
 LD:
-  name: Lódzkie
-  names: Lódzkie
+  name: Łódzkie
+  names: Łódzkie
 LU:
   name: Lubelskie
-  names:
-    - Lodzkie
+  names: Lubelskie
 MA:
-  name: Malopolskie
-  names:
-    - Malopolskie
+  name: Małopolskie
+  names: Małopolskie
 MZ:
   name: Mazowieckie
   names: Mazowieckie
@@ -36,17 +33,14 @@ PM:
   name: Pomorskie
   names: Pomorskie
 SK:
-  name: Swietokrzyskie
-  names:
-    - Swietokrzyskie
+  name: Świętokrzyskie
+  names: Świętokrzyskie
 SL:
-  name: Slaskie
-  names:
-    - Slaskie
+  name: Śląskie
+  names: Śląskie
 WN:
   name: Warminsko-mazurskie
-  names:
-    - Warminsko-Mazurskie
+  names: Warminsko-mazurskie
 WP:
   name: Wielkopolskie
   names: Wielkopolskie

--- a/lib/data/subdivisions/SA.yaml
+++ b/lib/data/subdivisions/SA.yaml
@@ -1,7 +1,7 @@
 ---
 ? "01"
 :
-  name: "Ar Riya?"
+  name: Ar Riyāḑ
   names:
     - ar-Riyad
     - ar-Riyād̨
@@ -33,38 +33,41 @@
     - Qaseem
 ? "06"
 :
-  name: "?a'il"
+  name: Ḩā'il
   names:
     - Hail
+    - Ha'il
 ? "07"
 :
-  name: Tabuk
+  name: Tabūk
   names:
     - Tabook
 08:
-  name: "Al ?udud ash Shamaliyah"
+  name: Al Ḩudūd ash Shamālīyah
   names:
-    - Northern
-    - "al-Hudud ash-Shamaliyah"
+    - Northern Borders
+    - al-Hudud ash-Shamaliyah
 09:
-  name: Jizan
+  name: Jāzān
   names:
     - Jizan
 ? "10"
 :
-  name: Najran
-  names: Najran
+  name: Najrān
+  names:
+  - Najran
 ? "11"
 :
-  name: "Al Ba?ah"
+  name: Al Bāḩah
   names:
+    - Al Bahah
     - Baha
 ? "12"
 :
-  name: "Al Jawf"
-  names: "Al Jawf"
+  name: Al Jawf
+  names: Al Jawf
 ? "14"
 :
-  name: "?Asir"
+  name: "'Asīr"
   names:
     - Aseer

--- a/lib/data/subdivisions/US.yaml
+++ b/lib/data/subdivisions/US.yaml
@@ -95,8 +95,10 @@ MO:
   names: Missouri
 MP:
   comment: "see also separate entry under MP"
-  name: "Northern Mariana Islands"
-  names: "Northern Mariana Islands"
+  name: "N. Mariana Islands"
+  names:
+    - "N. Mariana Islands"
+    - "Northern Mariana Islands"
 MS:
   name: Mississippi
   names: Mississippi
@@ -160,8 +162,10 @@ TX:
   names: Texas
 UM:
   comments: "see also separate entry under UM"
-  name: "United States Minor Outlying Islands"
-  names: "United States Minor Outlying Islands"
+  name: "US Minor Outlying Islands"
+  names:
+    - "US Minor Outlying Islands"
+    - "United States Minor Outlying Islands"
 UT:
   name: Utah
   names: Utah
@@ -170,8 +174,8 @@ VA:
   names: Virginia
 VI:
   comments: "see also separate entry under VI"
-  name: "Virgin Islands, U.S."
-  names: "Virgin Islands, U.S."
+  name: "Virgin Islands"
+  names: "Virgin Islands"
 VT:
   name: Vermont
   names: Vermont


### PR DESCRIPTION
Fixes corrupted Saudi Arabia's subdivisions names and tweaks PL ones.
Url: `/taxes` and Edit Tax Origin Address

**IMPORTANT:** After merging it there will be need to create next release version (`v0.8.7`) and to merge [this Chargify PR](https://github.com/chargify/chargify/pull/10461) that changes gem version in Gemfile.

Before:
<img width="276" alt="screen shot 2018-08-21 at 16 21 28" src="https://user-images.githubusercontent.com/12835055/44584084-109eff80-a7a8-11e8-9d39-b57bcc60ffa5.png">
After:
<img width="491" alt="fixedstates" src="https://user-images.githubusercontent.com/12835055/44584093-1ac0fe00-a7a8-11e8-8967-f0775bc6e194.png">


