### PR TITLE
[bugfix] Update Ireland Subdivision "Cork"

### DIFF
--- a/lib/data/subdivisions/IE.yaml
+++ b/lib/data/subdivisions/IE.yaml
@@ -1,8 +1,4 @@
 ---
-C:
-  name: Cork
-  names:
-    - Corcaigh
 CE:
   name: Clare
   names:
@@ -11,6 +7,11 @@ CN:
   name: Cavan
   names:
     - "An Cabhán"
+CO:
+  name: Cork
+  names:
+    - Corcaigh
+    - County Cork
 CW:
   name: Carlow
   names:


### PR DESCRIPTION
The subdivision "Cork" // County Cork has been update for Ireland to reflect the information from [Wikipedia](https://en.wikipedia.org/wiki/ISO_3166-2:IE).